### PR TITLE
Fix Error: Failed to build manual

### DIFF
--- a/R/solveSVR.R
+++ b/R/solveSVR.R
@@ -8,7 +8,7 @@
 #' Nu-support vector regression was performed using the svm function in the
 #' e1071 package in R. Parameters were set to nu = 0.5, type = “nu-regression”,
 #' kernel = “linear”, cost = 1, and all others to the default values.
-#' Bulk data and signature matrices were scaled to [−1, 1]. These parameter
+#' Bulk data and signature matrices were scaled to \code{m[−1, 1]}. These parameter
 #' and scaling choices match those specified in Schelker et al. in their
 #' MATLAB code, accessed through https://figshare.com/s/865e694ad06d5857db4b.
 #' As in Newman et al., model coefficients are extracted from the svm model

--- a/man/solveSVR.Rd
+++ b/man/solveSVR.Rd
@@ -23,7 +23,7 @@ kernel ="linear",cost = 1.
 Nu-support vector regression was performed using the svm function in the
 e1071 package in R. Parameters were set to nu = 0.5, type = “nu-regression”,
 kernel = “linear”, cost = 1, and all others to the default values.
-Bulk data and signature matrices were scaled to [−1, 1]. These parameter
+Bulk data and signature matrices were scaled to \code{m[−1, 1]}. These parameter
 and scaling choices match those specified in Schelker et al. in their
 MATLAB code, accessed through https://figshare.com/s/865e694ad06d5857db4b.
 As in Newman et al., model coefficients are extracted from the svm model


### PR DESCRIPTION
Hi Adriana, 

In the function solveSVR(), within the Description section I am replacing [-1, 1] by \code{m[-1, 1]} to avoid the Error with roxygen and latex when creating the manual.