### PR TITLE
add # to comments lines in example section to fix the parse error

### DIFF
--- a/R/DEAnalysisMAST.R
+++ b/R/DEAnalysisMAST.R
@@ -45,7 +45,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -71,7 +71,7 @@
 #'
 #' labels<-trueLabels
 #'
-# #Change to real labels
+#' #Change to real labels
 #' newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft",
 #'  "EE")
 #' for (i in 1:length(newcat)){

--- a/R/DEAnalysisSeurat.R
+++ b/R/DEAnalysisSeurat.R
@@ -19,7 +19,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -42,7 +42,7 @@
 #' #load("data/labels.RData") #read in single-cell labels from clustering
 #'
 #' labels<-trueLabels
-# #Change to real labels
+#' #Change to real labels
 #' newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft","EE")
 #' for (i in 1:length(newcat)){
 #'   labels[which(labels==(i-1))]<-newcat[i]

--- a/R/DEAnalysisSeuratIdents.R
+++ b/R/DEAnalysisSeuratIdents.R
@@ -19,7 +19,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -44,7 +44,7 @@
 #' #load("data/labels.RData") #read in single-cell labels from clustering
 #'
 #' labels<-trueLabels
-# #Change to real labels
+#' #Change to real labels
 #' newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth",
 #' "Tuft","EE")
 #' for (i in 1:length(newcat)){

--- a/R/MASTSignatureMatrixGivenDE.R
+++ b/R/MASTSignatureMatrixGivenDE.R
@@ -24,7 +24,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -44,7 +44,7 @@
 #'
 #' labels<-trueLabels
 #'
-# #Change to real labels
+#' #Change to real labels
 #' newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet",
 #' "Paneth","Tuft","EE")
 #' for (i in 1:length(newcat)){

--- a/R/Mean.in.log2space.R
+++ b/R/Mean.in.log2space.R
@@ -9,8 +9,8 @@
 #' @return Values
 #'
 #' @examples
-#'\donttest{
-#'#dataBulk
+#' \donttest{
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -19,7 +19,7 @@
 #' Mean.in.log2space(dataBulk, 0.1)
 #'}
 #'
-#'@export Mean.in.log2space
+#' @export Mean.in.log2space
 #'
 #' @importFrom dplyr "%>%"
 

--- a/R/buildSignatureMatrixMAST.R
+++ b/R/buildSignatureMatrixMAST.R
@@ -22,7 +22,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -48,7 +48,7 @@
 #'
 #' labels<-trueLabels
 #'
-# #Change to real labels
+#' #Change to real labels
 #' newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft",
 #' "EE")
 #' for (i in 1:length(newcat)){

--- a/R/buildSignatureMatrixUsingSeurat.R
+++ b/R/buildSignatureMatrixUsingSeurat.R
@@ -14,7 +14,7 @@
 #'
 #' @return Signature Matrix built using the Seurat algorithm
 #'
-#' @examples#
+#' @examples
 #'
 #' \donttest{
 #' #dataSC
@@ -23,7 +23,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -49,7 +49,7 @@
 #'
 #' labels<-trueLabels
 #'
-#' Change to real labels
+#' #Change to real labels
 #' newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft",
 #' "EE")
 #' for (i in 1:length(newcat)){

--- a/R/findDampeningConstant.R
+++ b/R/findDampeningConstant.R
@@ -17,7 +17,7 @@
 #' @return value (dampening constant value)
 #'
 #' @examples
-#'\donttest{
+#' \donttest{
 #' #Sig
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/Sig.RData"
 #' dest <- "data/Sig.RData"

--- a/R/m.auc.R
+++ b/R/m.auc.R
@@ -13,7 +13,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)
@@ -32,7 +32,7 @@
 #' load("data/trueLabels.RData")
 #'
 #' pseudo.count = 0.1
-#' data.used.log2   <- log2(dataSC+pseudo.count)
+#' data.used.log2 <- log2(dataSC+pseudo.count)
 #' colnames(data.used.log2)<-make.unique(colnames(data.used.log2))
 #' diff.cutoff=0.5
 #' id = labels

--- a/R/solveDampenedWLS.R
+++ b/R/solveDampenedWLS.R
@@ -24,7 +24,7 @@
 #' @return value (Dampened weighted least squares estimation values)
 #'
 #' @examples
-#'\donttest{
+#' \donttest{
 #' #Sig
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/Sig.RData"
 #' dest <- "data/Sig.RData"

--- a/R/solveDampenedWLSj.R
+++ b/R/solveDampenedWLSj.R
@@ -15,7 +15,7 @@
 #' @return value (Dampened weighted least squares estimation values)
 #'
 #' @examples
-#'\donttest{
+#' \donttest{
 #' #Sig
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/Sig.RData"
 #' dest <- "data/Sig.RData"

--- a/R/solveOLS.R
+++ b/R/solveOLS.R
@@ -10,7 +10,7 @@
 #' @return Cell-type proportion
 #'
 #' @examples
-#'\donttest{
+#' \donttest{
 #' #Sig
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/Sig.RData"
 #' dest <- "data/Sig.RData"

--- a/R/solveOLSInternal.R
+++ b/R/solveOLSInternal.R
@@ -10,7 +10,7 @@
 #' @return Cell numbers
 #'
 #' @examples
-#'\donttest{
+#' \donttest{
 #' #Sig
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/Sig.RData"
 #' dest <- "data/Sig.RData"

--- a/R/solveSVR.R
+++ b/R/solveSVR.R
@@ -31,7 +31,7 @@
 #' @return Value (SVR)
 #'
 #' @examples
-#'\donttest{
+#' \donttest{
 #' #Sig
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/Sig.RData"
 #' dest <- "data/Sig.RData"

--- a/R/stat.log2.R
+++ b/R/stat.log2.R
@@ -10,14 +10,14 @@
 #' @return A dataframe of the log2 applied results
 #'
 #' @examples
-#'\donttest{
+#' \donttest{
 #' #dataSC
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataSC.RData"
 #' dest <- "data/dataSC.RData"
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)

--- a/R/v.auc.R
+++ b/R/v.auc.R
@@ -18,7 +18,7 @@
 #' download.file(url, dest)
 #' load("data/dataSC.RData")
 #'
-#' dataBulk
+#' #dataBulk
 #' url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 #' dest <- "data/dataBulk.RData"
 #' download.file(url, dest)

--- a/man/DEAnalysisMAST.Rd
+++ b/man/DEAnalysisMAST.Rd
@@ -56,7 +56,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)
@@ -82,6 +82,7 @@ load("data/trueLabels.RData")
 
 labels<-trueLabels
 
+#Change to real labels
 newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft",
  "EE")
 for (i in 1:length(newcat)){

--- a/man/DEAnalysisSeurat.Rd
+++ b/man/DEAnalysisSeurat.Rd
@@ -30,7 +30,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)
@@ -53,6 +53,7 @@ load("data/trueLabels.RData")
 #load("data/labels.RData") #read in single-cell labels from clustering
 
 labels<-trueLabels
+#Change to real labels
 newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft","EE")
 for (i in 1:length(newcat)){
   labels[which(labels==(i-1))]<-newcat[i]

--- a/man/DEAnalysisSeuratIdents.Rd
+++ b/man/DEAnalysisSeuratIdents.Rd
@@ -30,7 +30,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)
@@ -55,6 +55,7 @@ load("data/trueLabels.RData")
 #load("data/labels.RData") #read in single-cell labels from clustering
 
 labels<-trueLabels
+#Change to real labels
 newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth",
 "Tuft","EE")
 for (i in 1:length(newcat)){

--- a/man/MASTSignatureMatrixGivenDE.Rd
+++ b/man/MASTSignatureMatrixGivenDE.Rd
@@ -43,7 +43,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)
@@ -63,6 +63,7 @@ load("data/trueLabels.RData")
 
 labels<-trueLabels
 
+#Change to real labels
 newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet",
 "Paneth","Tuft","EE")
 for (i in 1:length(newcat)){

--- a/man/buildSignatureMatrixMAST.Rd
+++ b/man/buildSignatureMatrixMAST.Rd
@@ -43,7 +43,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)
@@ -69,6 +69,7 @@ load("data/trueLabels.RData")
 
 labels<-trueLabels
 
+#Change to real labels
 newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft",
 "EE")
 for (i in 1:length(newcat)){

--- a/man/buildSignatureMatrixUsingSeurat.Rd
+++ b/man/buildSignatureMatrixUsingSeurat.Rd
@@ -36,7 +36,6 @@ This function builds a signature matrix using genes identified
 by the DEAnalysis() function.
 }
 \examples{
-#
 
 \donttest{
 #dataSC
@@ -45,7 +44,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)
@@ -71,7 +70,7 @@ load("data/trueLabels.RData")
 
 labels<-trueLabels
 
-Change to real labels
+#Change to real labels
 newcat<-c("NonCycISC","CycISC","TA","Ent","PreEnt","Goblet","Paneth","Tuft",
 "EE")
 for (i in 1:length(newcat)){

--- a/man/m.auc.Rd
+++ b/man/m.auc.Rd
@@ -27,7 +27,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)
@@ -46,7 +46,7 @@ download.file(url, dest)
 load("data/trueLabels.RData")
 
 pseudo.count = 0.1
-data.used.log2   <- log2(dataSC+pseudo.count)
+data.used.log2 <- log2(dataSC+pseudo.count)
 colnames(data.used.log2)<-make.unique(colnames(data.used.log2))
 diff.cutoff=0.5
 id = labels

--- a/man/stat.log2.Rd
+++ b/man/stat.log2.Rd
@@ -28,7 +28,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)

--- a/man/v.auc.Rd
+++ b/man/v.auc.Rd
@@ -28,7 +28,7 @@ dest <- "data/dataSC.RData"
 download.file(url, dest)
 load("data/dataSC.RData")
 
-dataBulk
+#dataBulk
 url <- "https://github.com/sistia01/DWLS/raw/main/inst/extdata/dataBulk.RData"
 dest <- "data/dataBulk.RData"
 download.file(url, dest)


### PR DESCRIPTION
Some lines with comments in the example section were lacking the # symbol causing the parse error